### PR TITLE
Update __init__.py

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -799,6 +799,7 @@ class Config():
                     supervisorConfig += "command=%s" % (command)
                     supervisorConfig += "autostart=%s\n" % (odr['autostart'])
                     supervisorConfig += "autorestart=true\n"
+                    supervisorConfig += "startretries=65535\n"
                     supervisorConfig += "priority=10\n"
                     supervisorConfig += "user=odr\n"
                     supervisorConfig += "group=odr\n"


### PR DESCRIPTION
Ask supervisord to aggressively attempt to restart the encoders. This should help when transcoding unreliable webstreams from the internet. Currently supervisord gives up quickly and returns 'FATAL'. I have assumed the value 65535 means never give up. A smaller value might be adequate and not stuff the logs with error messages.